### PR TITLE
Copy each rule to its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installs [Elastalert](https://github.com/Yelp/elastalert) along with relative al
 Role Variables
 --------------
 
-```
+```yaml
 # General settings
 elastalert_version: 0.1.15
 elastalert_rules_dir: example_rules

--- a/tasks/elastalert.yml
+++ b/tasks/elastalert.yml
@@ -30,10 +30,15 @@
   become_user: "{{ elastalert_user }}"
   become: yes
 
-- name: Empty up the rules directory
-  file:
-    state: absent
-    path: "{{ elastalert_etc_root }}/{{ elastalert_rules_dir }}/"
+- name: Read File system stats of the rules directory
+  stat: 
+    path: "{{ elastalert_etc_root }}/{{ elastalert_rules_dir }}"
+  register: rules_dir_stats
+
+- name: Fail installation when rules directory exists as a file
+  fail:
+    msg: "The rules directory already exists but it is a file"
+  when: rules_dir_stats.stat.exists and rules_dir_stats.stat.isreg
 
 - name: Ensure rules directory exists
   file:

--- a/tasks/elastalert.yml
+++ b/tasks/elastalert.yml
@@ -30,10 +30,15 @@
   become_user: "{{ elastalert_user }}"
   become: yes
 
+- name: Ensure rules directory exists
+  file:
+    state: directory
+    path: "{{ elastalert_etc_root }}/{{ elastalert_rules_dir }}/"
+
 - name: Copy over alert files
   copy:
     src: "{{ item }}"
-    dest: "{{ elastalert_etc_root }}/{{ elastalert_rules_dir }}"
+    dest: "{{ elastalert_etc_root }}/{{ elastalert_rules_dir }}/"
     owner: root
     group: root
     validate: "{{ elastalert_venv_rootdir }}/venv/bin/elastalert-test-rule --config {{ elastalert_etc_root }}/config.yaml %s"

--- a/tasks/elastalert.yml
+++ b/tasks/elastalert.yml
@@ -30,6 +30,11 @@
   become_user: "{{ elastalert_user }}"
   become: yes
 
+- name: Empty up the rules directory
+  file:
+    state: absent
+    path: "{{ elastalert_etc_root }}/{{ elastalert_rules_dir }}/"
+
 - name: Ensure rules directory exists
   file:
     state: directory


### PR DESCRIPTION
I had to make this change for each rule to exist as its own file.
Before it was putting everything into `/etc/elastalert/rules`.
Once I made this change locally my rules started to work.