### PR TITLE
Upgrade to 0.2.2, use python3, ES lib 6.8.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General settings
-elastalert_version: 0.1.39
+elastalert_version: 0.2.2
 elastalert_rules_dir: rules
 elastalert_rules_files: []
 elastalert_rules_templates: []
@@ -22,10 +22,9 @@ elastalert_es_run_every:
 
 # System pkg dependencies
 elastalert_pkgs:
-  # - python3-virtualenv
-  # - python3-dev
+  - python3-virtualenv
+  - python3-dev
   - virtualenv
-  - python-dev
   - gcc
   - libssl-dev
 
@@ -33,8 +32,8 @@ elastalert_pkgs:
 elastalert_etc_root: /etc/elastalert
 elastalert_etc_rules_dir: "{{ elastalert_etc_root }}/rules"
 elastalert_venv_rootdir: /opt/elastalert/
-elastalert_venv_python: python2
+elastalert_venv_python: python3
 elastalert_user: elastalert
 elastalert_group: "{{ elastalert_user }}"
 # If elasticsearch>=7, then remote ES host must run 7.x or higher.
-elastalert_es_pip_version: "6.4.0"
+elastalert_es_pip_version: "6.8.1"


### PR DESCRIPTION
The versions we were installing previously weren't available anymore (and failed with python2 anyway), so let's go to latest elastalert and 6.8 ES lib (should be compatible with 6.7 server). Closes https://github.com/freedomofpress/infrastructure/issues/2637.

Correction: not-quite-latest. Hit an error with 0.2.4, we might need to upgrade ES first. Rolling back to 0.2.2 for now.