### PR TITLE
Adds option to specify rules using ansible variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Role Variables
 # General settings
 elastalert_version: 0.1.15
 elastalert_rules_dir: example_rules
+elastalert_rules:
+  - name: Flatline rule
+    type: flatline
 elastalert_alert_time_limit:
   days: 2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ elastalert_version: 0.2.2
 elastalert_rules_dir: rules
 elastalert_rules_files: []
 elastalert_rules_templates: []
+elastalert_rules: []
 elastalert_alert_time_limit:
   days: 2
 elastalert_buffer_time:

--- a/tasks/elastalert.yml
+++ b/tasks/elastalert.yml
@@ -37,7 +37,7 @@
   args:
     chdir: "{{ elastalert_venv_rootdir }}"
     executable: /bin/bash
-  when: elastalert_index_result.failed
+  when: elastalert_index_result is failed
   become_user: "{{ elastalert_user }}"
   become: yes
 

--- a/tasks/elastalert.yml
+++ b/tasks/elastalert.yml
@@ -81,6 +81,17 @@
   with_fileglob: "{{ elastalert_rules_templates }}"
   notify: restart elastalert
 
+- name: Deploy rules from variables
+  copy:
+    content: "{{ item | to_nice_yaml(explicit_start=true) }}"
+    dest: "{{ elastalert_etc_root }}/{{ elastalert_rules_dir }}/{{ item.name | replace(' ', '-') | lower }}.yml"
+    owner: root
+    group: "{{ elastalert_group }}"
+    mode: "0640"
+    validate: "{{ elastalert_venv_rootdir }}/venv/bin/elastalert-test-rule --config {{ elastalert_etc_root }}/config.yaml %s"
+  with_items: "{{ elastalert_rules }}"
+  notify: restart elastalert
+
 - name: Enable elastalert service
   service:
     name: elastalert


### PR DESCRIPTION
Since elastalert uses yaml for configuration, there is really no need to carry templates around and you can keep everything in a single playbook.