### PR TITLE
Pick ElastAlert2 based on version number

### DIFF
--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -20,7 +20,7 @@
 
 - name: Install elastalert into virtualenv
   pip:
-    name: elastalert
+    name: "elastalert{{ '2' if 2 <= (elastalert_version.split('.')[0] | int)  else '' }}"
     version: "{{ elastalert_version }}"
     virtualenv: "{{ elastalert_venv_rootdir }}/venv"
     virtualenv_python: "{{ elastalert_venv_python }}"


### PR DESCRIPTION
 Since ElastAlert appears to be mostly dead (https://github.com/Yelp/elastalert/issues/3178), supporting the community fork (https://github.com/jertel/elastalert2) makes sense.